### PR TITLE
GIT: gitattributes gitignore

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,15 @@
+# Auto detect text files and perform LF normalization
+*.py text=auto eol=lf
+*.pyx text=auto eol=lf
+*.cpp text=auto eol=lf
+*.h text=auto eol=lf
+*.rst text=auto eol=lf
+*.txt text=auto eol=lf
+*.yml text=auto eol=lf
+*.md text=auto eol=lf
+*.dat text=auto eol=lf
+
+# Force git to look at some files as binary
+*.png binary
+*.pdf binary
+*.hdf binary

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+*.pyc
+.idea
+.DS_Store
+__pycache__
+.ipynb_checkpoints/


### PR DESCRIPTION
Adding gitattributes and gitignore will make admin, etc, easier in the long run. Especially if people are contributing from different OS's.