### PR TITLE
MAINT: don't install pyopencl for refnx

### DIFF
--- a/.github/workflows/validation.yml
+++ b/.github/workflows/validation.yml
@@ -29,8 +29,7 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install -y --no-install-recommends python3-dev \
-            python3-pip python3-venv build-essential opencl-headers \
-            ocl-icd-opencl-dev libpocl2
+            python3-pip python3-venv build-essential
 
       - name: Install Python packages
         run: |
@@ -39,8 +38,7 @@ jobs:
 
           python3 -m pip install --upgrade pip
           python3 -m pip install wheel setuptools
-          python3 -m pip install numpy scipy cython pytest black mako
-          python3 -m pip install pyopencl
+          python3 -m pip install numpy scipy cython pytest black
           python3 -m pip install refnx
 
       - name: Validate

--- a/.github/workflows/validation.yml
+++ b/.github/workflows/validation.yml
@@ -28,7 +28,9 @@ jobs:
       - name: setup apt dependencies
         run: |
           sudo apt-get update
-          sudo apt-get install -y --no-install-recommends python3-dev python3-pip python3-venv build-essential
+          sudo apt-get install -y --no-install-recommends python3-dev \
+            python3-pip python3-venv build-essential opencl-headers \
+            ocl-icd-opencl-dev libpocl2
 
       - name: Install Python packages
         run: |
@@ -37,7 +39,8 @@ jobs:
 
           python3 -m pip install --upgrade pip
           python3 -m pip install wheel setuptools
-          python3 -m pip install numpy scipy cython pytest black pyopencl
+          python3 -m pip install numpy scipy cython pytest black mako
+          python3 -m pip install pyopencl
           python3 -m pip install refnx
 
       - name: Validate


### PR DESCRIPTION
It doesn't seem to be possible at the moment to run pyopencl based calculations on GH actions (at least not on Ubuntu)