### PR TITLE
adding tests for kernel of NIST web reflectivity calculator

### DIFF
--- a/.github/workflows/validate_bornagain.yml
+++ b/.github/workflows/validate_bornagain.yml
@@ -73,17 +73,15 @@ jobs:
         mkdir build && pushd build
 
         cmake -DBA_PY_PACKAGE=ON -DBA_GUI=OFF -DBA_TIFF_SUPPORT=OFF -DCMAKE_INSTALL_PREFIX=/usr/local ../
-        make package_source
         make -j4
-        sudo make install
+        pushd PythonPackage/*
+        python3 setup.py install
 
     - name: Validate
       run: |
         # source /usr/local/bin/thisbornagain.sh
         ls -al /usr/local/bin
         export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/usr/local/lib
-        # this is fragile: depends on python version installed in ubuntu
-        export PYTHONPATH=$PYTHONPATH:/usr/local/python/3.8/dist-packages
         printenv
         # run validation via pytest (for Python packages)
-        python -m pytest validation/scripts/test_bornagain.py
+        python3 -m pytest validation/scripts/test_bornagain.py

--- a/.github/workflows/validate_bornagain.yml
+++ b/.github/workflows/validate_bornagain.yml
@@ -64,15 +64,15 @@ jobs:
         python3 -m pip install numpy matplotlib
 
     - name: Build BornAgain
-      env:
-        QT_QPA_PLATFORM: offscreen
       run: |
         git clone --depth 1 --single-branch --branch main https://jugit.fz-juelich.de/mlz/bornagain.git
         pushd bornagain
         git submodule update
+        # disable tests, since there is no CMake option to do so:
+        sed -i 's/add_subdirectory(Tests/# add_subdirectory(Tests/g' CMakeLists.txt
         mkdir build && pushd build
 
-        cmake -DBA_GUI=0 -DBA_TIFF_SUPPORT=0 -DCMAKE_INSTALL_PREFIX=/usr/local ../
+        cmake -DBA_PY_PACKAGE=ON -DBA_GUI=OFF -DBA_TIFF_SUPPORT=OFF -DCMAKE_INSTALL_PREFIX=/usr/local ../
         make package_source
         make -j4
         sudo make install
@@ -82,6 +82,8 @@ jobs:
         # source /usr/local/bin/thisbornagain.sh
         ls -al /usr/local/bin
         export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/usr/local/lib
+        # this is fragile: depends on python version installed in ubuntu
+        export PYTHONPATH=$PYTHONPATH:/usr/local/python/3.8/dist-packages
         printenv
         # run validation via pytest (for Python packages)
         python -m pytest validation/scripts/test_bornagain.py

--- a/.github/workflows/validate_bornagain.yml
+++ b/.github/workflows/validate_bornagain.yml
@@ -75,7 +75,7 @@ jobs:
         cmake -DBA_PY_PACKAGE=ON -DBA_GUI=OFF -DBA_TIFF_SUPPORT=OFF -DCMAKE_INSTALL_PREFIX=/usr/local ../
         make -j4
         pushd PythonPackage/*
-        python3 setup.py install
+        python3 -m pip install .
 
     - name: Validate
       run: |

--- a/.github/workflows/validate_bornagain.yml
+++ b/.github/workflows/validate_bornagain.yml
@@ -72,7 +72,7 @@ jobs:
         git submodule update
         mkdir build && pushd build
 
-        cmake -DCMAKE_INSTALL_PREFIX=/usr/local ../
+        cmake -DBA_GUI=0 -DBA_TIFF_SUPPORT=0 -DCMAKE_INSTALL_PREFIX=/usr/local ../
         make package_source
         make -j4
         sudo make install

--- a/.github/workflows/validate_nistweb.yml
+++ b/.github/workflows/validate_nistweb.yml
@@ -1,0 +1,42 @@
+name: ORSO Val. NIST Web Calculator
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+  schedule:
+    - cron:  '0 0 * * 1'
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+
+jobs:
+  validate_ref1d:
+    runs-on: ubuntu-20.04
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: setup apt dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends python3-dev python3-pip python3-venv build-essential
+
+      - name: Install Python packages
+        run: |
+          python3 -m venv validate
+          source validate/bin/activate
+
+          python3 -m pip install --upgrade pip
+          python3 -m pip install wheel setuptools
+          python3 -m pip install numpy scipy cython pytest
+          # install refl1d from source (because the last release requires
+          # wxpython which requires a lot of time to build, the git repo doesn't
+          # at time of writing)
+          python3 -m pip install git+https://github.com/reflectometry/refl1d.git
+
+      - name: Validate
+        run: |
+          source validate/bin/activate
+          # run validation via pytest (for Python packages)
+          pytest validation/scripts/test_nistweb.py

--- a/.github/workflows/validate_nistweb.yml
+++ b/.github/workflows/validate_nistweb.yml
@@ -29,11 +29,7 @@ jobs:
 
           python3 -m pip install --upgrade pip
           python3 -m pip install wheel setuptools
-          python3 -m pip install numpy scipy cython pytest
-          # install refl1d from source (because the last release requires
-          # wxpython which requires a lot of time to build, the git repo doesn't
-          # at time of writing)
-          python3 -m pip install git+https://github.com/reflectometry/refl1d.git
+          python3 -m pip install numpy scipy cython pytest requests
 
       - name: Validate
         run: |

--- a/.github/workflows/validate_nistweb.yml
+++ b/.github/workflows/validate_nistweb.yml
@@ -11,7 +11,7 @@ on:
 
 
 jobs:
-  validate_ref1d:
+  validate_nistweb:
     runs-on: ubuntu-20.04
 
     steps:

--- a/validation/scripts/nistweb/magrefl_wrapper.mjs
+++ b/validation/scripts/nistweb/magrefl_wrapper.mjs
@@ -1,0 +1,24 @@
+#!/usr/bin/env node
+
+import module_factory from "./refl/magrefl.js";
+const refl_module = await module_factory();
+
+const stdin = process.openStdin();
+
+let data = "";
+
+stdin.on('data', function(chunk) {
+  data += chunk;
+});
+
+stdin.on('end', async function() {
+  const json_data = JSON.parse(data);
+  const { depth, sigma, rho, irho, rhoM, thetaM, H, AGUIDE, kz } = json_data;
+  const R = refl_module.magrefl_less(depth, sigma, rho, irho, rhoM, thetaM, H, AGUIDE, kz);
+  const output = JSON.stringify({ kz, R });
+  console.log(output);
+});
+
+function magsq(a) {
+  return Math.pow(a[0], 2) + Math.pow(a[1], 2);
+}

--- a/validation/scripts/nistweb/refl_wrapper.mjs
+++ b/validation/scripts/nistweb/refl_wrapper.mjs
@@ -1,0 +1,24 @@
+#!/usr/bin/env node
+
+import module_factory from "./refl.js";
+const refl_module = await module_factory();
+
+const stdin = process.openStdin();
+
+let data = "";
+
+stdin.on('data', function(chunk) {
+  data += chunk;
+});
+
+stdin.on('end', async function() {
+  const json_data = JSON.parse(data);
+  const { depth, sigma, rho, irho, kz } = json_data;
+  const R = refl_module.refl(depth, sigma, rho, irho, kz);
+  const output = JSON.stringify({ kz, R });
+  console.log(output);
+});
+
+function magsq(a) {
+  return Math.pow(a[0], 2) + Math.pow(a[1], 2);
+}

--- a/validation/scripts/test_nistweb.py
+++ b/validation/scripts/test_nistweb.py
@@ -1,0 +1,115 @@
+import requests
+import tarfile
+import io
+import os
+import shutil
+import json
+import warnings
+import subprocess
+
+import pytest
+import numpy as np
+from test_discovery import get_test_data
+
+tests = list(get_test_data())
+ids = [f"{t[0]}" for t in tests]
+
+LOCAL_NODE_INSTALL_PATH = "node_tmp"
+
+@pytest.fixture(scope="module")
+def local_nodeenv():
+    return install_local_nodeenv()
+    
+@pytest.mark.parametrize("nsd", tests, ids=ids)
+def test_nistweb(nsd, local_nodeenv):
+    """
+    Run validation for NIST web calculator
+
+    Parameters
+    ----------
+    nsd: tuple
+        test_name, slabs, data
+    """
+    # NCOLS of data:
+    # 2 - test kernel only
+    # 3 - test kernel and chi2 calculation
+    # 4 - test resolution smearing and chi2 calculation
+
+    test_name, slabs, data = nsd
+
+    if data.shape[1] == 4:
+        # resolution smeared
+        warnings.warn("not testing resolution for web calculator")
+    elif data.shape[1] < 4:
+        # no resolution data, just test kernel
+        kernel_test(test_name, slabs, data, local_nodeenv)
+
+
+
+def kernel_test(test_name, slabs, data, local_nodeenv):
+    """
+    Test the reflectivity kernels for refnx.
+
+    Parameters
+    ----------
+    slabs: np.ndarray
+        Slab representation of the system
+    data: np.ndarray
+        Q, R arrays
+    """
+    node_bin, refl_wrapper, magrefl_wrapper = local_nodeenv
+    kz = data[:, 0]/2.0
+    json_data = {
+        "depth": list(slabs[:, 0]),
+        "rho": list(slabs[:, 1]),
+        "irho": list(slabs[:, 2]),
+        "sigma": list(slabs[1:, 3]),
+        "kz": list(kz)
+    }
+
+    p = subprocess.Popen([node_bin, refl_wrapper], stdin=subprocess.PIPE, stdout=subprocess.PIPE)
+    raw_output, raw_errors = p.communicate(json.dumps(json_data).encode())
+
+    output = json.loads(raw_output)
+    r_raw = np.array(output["R"])
+    r_real = r_raw[:, 0]
+    r_imag = r_raw[:, 1]
+    r = r_real + 1j * r_imag
+    R = (r * np.conj(r)).real
+    
+    assert R.shape == data[:, 1].shape
+
+    np.testing.assert_allclose(R, data[:, 1], rtol=8e-5)
+    
+
+
+
+def install_local_nodeenv(path="tmp", version="v16.15.0", clean=False):
+    """ returns path to node executable and refl and magrefl node wrappers """
+    node_path = "node-{version}-linux-x64".format(version=version)
+    if clean:
+        os.rmtree(path)
+    os.makedirs(os.path.join(path), exist_ok=True)
+    
+    node_exe_path = os.path.join(path, node_path, "bin", "node")
+    if not os.path.exists(node_exe_path):
+        # print("installing node")
+        noderaw = requests.get("https://nodejs.org/dist/{version}/node-{version}-linux-x64.tar.xz".format(version=version))
+        nodebytes = io.BytesIO(noderaw.content)
+        nodebytes.seek(0)
+    
+        with tarfile.open(fileobj=nodebytes) as t:
+            t.extractall(path)
+    
+    magrefl = requests.get("https://raw.githubusercontent.com/usnistgov/reflectometry-calculators/nist-pages/js/refl/magrefl.js")
+    open(os.path.join(path, "magrefl.js"), "wb").write(magrefl.content)
+    
+    refl = requests.get("https://raw.githubusercontent.com/usnistgov/reflectometry-calculators/nist-pages/js/refl/refl.js")
+    open(os.path.join(path, "refl.js"), "wb").write(refl.content)
+    
+    shutil.copy2("scripts/nistweb/magrefl_wrapper.mjs", os.path.join(path, "magrefl_wrapper.mjs"))
+    shutil.copy2("scripts/nistweb/refl_wrapper.mjs", os.path.join(path, "refl_wrapper.mjs"))
+    return os.path.join(path, node_path, "bin", "node"), os.path.join(path, "refl_wrapper.mjs"), os.path.join(path, "magrefl_wrapper.mjs")
+    
+
+

--- a/validation/scripts/test_nistweb.py
+++ b/validation/scripts/test_nistweb.py
@@ -16,10 +16,12 @@ ids = [f"{t[0]}" for t in tests]
 
 LOCAL_NODE_INSTALL_PATH = "node_tmp"
 
+
 @pytest.fixture(scope="module")
 def local_nodeenv():
     return install_local_nodeenv()
-    
+
+
 @pytest.mark.parametrize("nsd", tests, ids=ids)
 def test_nistweb(nsd, local_nodeenv):
     """
@@ -45,7 +47,6 @@ def test_nistweb(nsd, local_nodeenv):
         kernel_test(test_name, slabs, data, local_nodeenv)
 
 
-
 def kernel_test(test_name, slabs, data, local_nodeenv):
     """
     Test the reflectivity kernels for refnx.
@@ -58,16 +59,18 @@ def kernel_test(test_name, slabs, data, local_nodeenv):
         Q, R arrays
     """
     node_bin, refl_wrapper, magrefl_wrapper = local_nodeenv
-    kz = data[:, 0]/2.0
+    kz = data[:, 0] / 2.0
     json_data = {
         "depth": list(slabs[:, 0]),
         "rho": list(slabs[:, 1]),
         "irho": list(slabs[:, 2]),
         "sigma": list(slabs[1:, 3]),
-        "kz": list(kz)
+        "kz": list(kz),
     }
 
-    p = subprocess.Popen([node_bin, refl_wrapper], stdin=subprocess.PIPE, stdout=subprocess.PIPE)
+    p = subprocess.Popen(
+        [node_bin, refl_wrapper], stdin=subprocess.PIPE, stdout=subprocess.PIPE
+    )
     raw_output, raw_errors = p.communicate(json.dumps(json_data).encode())
 
     output = json.loads(raw_output)
@@ -76,47 +79,61 @@ def kernel_test(test_name, slabs, data, local_nodeenv):
     r_imag = r_raw[:, 1]
     r = r_real + 1j * r_imag
     R = (r * np.conj(r)).real
-    
+
     assert R.shape == data[:, 1].shape
 
     np.testing.assert_allclose(R, data[:, 1], rtol=8e-5)
-    
-
 
 
 def install_local_nodeenv(path="tmp", version="v16.15.0", clean=False):
-    """ returns path to node executable and refl and magrefl node wrappers """
+    """returns path to node executable and refl and magrefl node wrappers"""
     current_folder = os.path.dirname(__file__)
     test_folder = os.path.join(os.path.dirname(current_folder), "test")
     node_path = "node-{version}-linux-x64".format(version=version)
     if clean:
         os.rmtree(path)
-    
+
     working_folder = os.path.join(test_folder, path)
     os.makedirs(working_folder, exist_ok=True)
-    
+
     node_exe_path = os.path.join(working_folder, node_path, "bin", "node")
     if not os.path.exists(node_exe_path):
         # print("installing node")
-        noderaw = requests.get("https://nodejs.org/dist/{version}/node-{version}-linux-x64.tar.xz".format(version=version))
+        noderaw = requests.get(
+            "https://nodejs.org/dist/{version}/node-{version}-linux-x64.tar.xz".format(
+                version=version
+            )
+        )
         nodebytes = io.BytesIO(noderaw.content)
         nodebytes.seek(0)
-    
+
         with tarfile.open(fileobj=nodebytes) as t:
             t.extractall(working_folder)
-    
-    magrefl = requests.get("https://raw.githubusercontent.com/usnistgov/reflectometry-calculators/nist-pages/js/refl/magrefl.js")
-    open(os.path.join(working_folder, "magrefl.js"), "wb").write(magrefl.content)
-    
-    refl = requests.get("https://raw.githubusercontent.com/usnistgov/reflectometry-calculators/nist-pages/js/refl/refl.js")
+
+    magrefl = requests.get(
+        "https://raw.githubusercontent.com/usnistgov/reflectometry-calculators/nist-pages/js/refl/magrefl.js"
+    )
+    open(os.path.join(working_folder, "magrefl.js"), "wb").write(
+        magrefl.content
+    )
+
+    refl = requests.get(
+        "https://raw.githubusercontent.com/usnistgov/reflectometry-calculators/nist-pages/js/refl/refl.js"
+    )
     open(os.path.join(working_folder, "refl.js"), "wb").write(refl.content)
-    
-    shutil.copy2(os.path.join(current_folder, "nistweb", "magrefl_wrapper.mjs"), os.path.join(working_folder, "magrefl_wrapper.mjs"))
-    shutil.copy2(os.path.join(current_folder, "nistweb", "refl_wrapper.mjs"), os.path.join(working_folder, "refl_wrapper.mjs"))
+
+    shutil.copy2(
+        os.path.join(current_folder, "nistweb", "magrefl_wrapper.mjs"),
+        os.path.join(working_folder, "magrefl_wrapper.mjs"),
+    )
+    shutil.copy2(
+        os.path.join(current_folder, "nistweb", "refl_wrapper.mjs"),
+        os.path.join(working_folder, "refl_wrapper.mjs"),
+    )
     refl_wrapper_path = os.path.join(working_folder, "refl_wrapper.mjs")
     magrefl_wrapper_path = os.path.join(working_folder, "magrefl_wrapper.mjs")
     return node_exe_path, refl_wrapper_path, magrefl_wrapper_path
-    
+
 
 if __name__ == "__main__":
     local_nodeenv = install_local_nodeenv()


### PR DESCRIPTION
test the WebAssembly kernel used in the NIST reflectometry calculator at https://pages.nist.gov/reflectometry-calculators/reflectivity-calculator.html

No resolution correction is available in the web calculator, and those tests are skipped.

When the polarised-beam tests in pyodide/pyodide#66 are merged, this can also be updated to check the kernel for the polarised calculator at https://pages.nist.gov/reflectometry-calculators/magnetic-reflectivity-calculator.html